### PR TITLE
Fixed group name in french version

### DIFF
--- a/Configs/TasksSequence_HardenAD.xml
+++ b/Configs/TasksSequence_HardenAD.xml
@@ -1092,7 +1092,7 @@
 		<!-- FR-FR -->
 		<!--
 		<Group name="Administrateurs de l’entreprise" Category="Security" Scope="Universal" Description="" Path="CN=Users,ROOTDN">
-			<Member samAccountName="GS_T0_Managers" />
+			<Member samAccountName="G-S-T0_Managers" />
 		</Group>
 		-->
 		<!-- FR-FR -->


### PR DESCRIPTION
## Bug
The T0 manager group **G-S-T0_Managers** is never added to the builtin group **Administrateurs de l’entreprise** in the commented french version.

## Explanation
In the EN-US version, this works correctly because the samAccountName value is **G-S-T0_Managers** but in the French version, the samAccountName value is **GS_T0_Managers** = ! **G-S-T0_Managers**. In fact, **GS_T0_Managers** doesn't exist and will therefore never be added to the builtin group **Administrateurs de l’entreprise** .

## Fix
Replace  `<Member samAccountName="GS_T0_Managers" />` by `<Member samAccountName="G-S-T0_Managers" />`
