### PR TITLE
Fix member name format in HAD-LocalAdmins GPOs for T2, T2L, and T1L

### DIFF
--- a/Inputs/GroupPolicies/HAD-LocalAdmins-T1L/{BFB98271-72B9-4791-BBFC-E76513A86AB8}/DomainSysvol/GPO/Machine/Preferences/Groups/Groups.xml
+++ b/Inputs/GroupPolicies/HAD-LocalAdmins-T1L/{BFB98271-72B9-4791-BBFC-E76513A86AB8}/DomainSysvol/GPO/Machine/Preferences/Groups/Groups.xml
@@ -10,7 +10,7 @@
 	<Group clsid="{6D4A79E4-529C-4481-ABD0-F5BD7EA93BA7}" name="Administrators (built-in)" image="2" changed="2023-03-09 15:06:30" uid="{6C048F9D-E43C-4A2D-98D6-89AF06B79842}" userContext="0" removePolicy="1">
 		<Properties action="U" newName="" description="" deleteAllUsers="0" deleteAllGroups="0" removeAccounts="1" groupSid="S-1-5-32-544" groupName="Administrators (built-in)">
 			<Members>
-				<Member name="HARDEN\L-S_LocalAdmins-%ComputerName%" action="ADD" sid=""/>
+				<Member name="HARDEN\L-S-LocalAdmins-%ComputerName%" action="ADD" sid=""/>
 			</Members>
 		</Properties>
 	</Group>

--- a/Inputs/GroupPolicies/HAD-LocalAdmins-T2/{DBB5A54A-4338-4D59-A25E-BD71CEBB86B2}/DomainSysvol/GPO/Machine/Preferences/Groups/Groups.xml
+++ b/Inputs/GroupPolicies/HAD-LocalAdmins-T2/{DBB5A54A-4338-4D59-A25E-BD71CEBB86B2}/DomainSysvol/GPO/Machine/Preferences/Groups/Groups.xml
@@ -10,7 +10,7 @@
 	<Group clsid="{6D4A79E4-529C-4481-ABD0-F5BD7EA93BA7}" name="Administrators (built-in)" image="2" changed="2023-03-09 15:07:13" uid="{9BBF3B07-B61E-48D4-8432-73EA7088AD5C}" userContext="0" removePolicy="1">
 		<Properties action="U" newName="" description="" deleteAllUsers="0" deleteAllGroups="0" removeAccounts="1" groupSid="S-1-5-32-544" groupName="Administrators (built-in)">
 			<Members>
-				<Member name="HARDEN\L-S_LocalAdmins-%ComputerName%" action="ADD" sid=""/>
+				<Member name="HARDEN\L-S-LocalAdmins-%ComputerName%" action="ADD" sid=""/>
 			</Members>
 		</Properties>
 	</Group>

--- a/Inputs/GroupPolicies/HAD-LocalAdmins-T2L/{F1824E32-8FAF-4203-8799-BCD9FEE8681A}/DomainSysvol/GPO/Machine/Preferences/Groups/Groups.xml
+++ b/Inputs/GroupPolicies/HAD-LocalAdmins-T2L/{F1824E32-8FAF-4203-8799-BCD9FEE8681A}/DomainSysvol/GPO/Machine/Preferences/Groups/Groups.xml
@@ -10,7 +10,7 @@
 	<Group clsid="{6D4A79E4-529C-4481-ABD0-F5BD7EA93BA7}" name="Administrators (built-in)" image="2" changed="2023-03-09 15:08:00" uid="{51797F8A-0B7B-4814-B65B-6735FD525B32}" userContext="0" removePolicy="1">
 		<Properties action="U" newName="" description="" deleteAllUsers="0" deleteAllGroups="0" removeAccounts="1" groupSid="S-1-5-32-544" groupName="Administrators (built-in)">
 			<Members>
-				<Member name="HARDEN\L-S_LocalAdmins-%ComputerName%" action="ADD" sid=""/>
+				<Member name="HARDEN\L-S-LocalAdmins-%ComputerName%" action="ADD" sid=""/>
 			</Members>
 		</Properties>
 	</Group>


### PR DESCRIPTION
**Describe the bug**
In the following GPOs:
- HAD-LocalAdmins-T2
- HAD-LocalAdmins-T1L
- HAD-LocalAdmins-T2L

The `%DN%` and `%Prefix-domLoc%` group are not translated correctly and remain as: : `HARDEN\L-S_LocalAdmins-%ComputerName%`

**To Reproduce**
Steps to reproduce the behavior:
1. Setup HAD with the GPO importation.
2. Open the Group Policy Editor.
3. In the HAD-LocalAdmins-T2 / HAD-LocalAdmins-T1L / HAD-LocalAdmins-T2L GPOs, the group `HARDEN\L-S_LocalAdmins-%ComputerName%` is not resolved correctly with the `%DN%` and `%Prefix-domLoc%` well-known ID.

**Quick Fix**
Before:
`<Member name="HARDEN\L-S_LocalAdmins-%ComputerName%" action="ADD" sid=""/>`
After:
`<Member name="HARDEN\L-S-LocalAdmins-%ComputerName%" action="ADD" sid=""/>`

This change works because in the translation.xml file, we have the following translation rule:
`<replace id="13" find="HARDEN\L-S-LocalAdmins-%ComputerName%" replaceBy="%NetBios%\%Prefix-domLoc%%Groups_Computers%"/>
`

