### PR TITLE
Fix TargetOU translation

### DIFF
--- a/Modules/module-activeDirectory/module-activeDirectory.psm1
+++ b/Modules/module-activeDirectory/module-activeDirectory.psm1
@@ -1519,7 +1519,7 @@ Function Set-LapsPermissions {
                 $Granting = $cfgXml.Settings.LocalAdminPasswordSolution.AdmPwdSelfPermission
                 foreach ($Granted in $Granting) {
                     Try {
-                        #$TargetOU = $Granted.Target
+                        $TargetOU = $Granted.Target
                         #foreach ($transID in $translat.wellKnownID) {
                         #    $TargetOU = $TargetOU -replace $TransID.translateFrom, $TransID.translateTo
                         #}


### PR DESCRIPTION
### Describe the bug
The script show a warning when the task `Set-Up LAPS permissions on the target domain` is enabled. Because the `$TargetOU` variable is empty.

### To Reproduce
Steps to reproduce the behavior:
1. Run `HardenAD.ps1` with the task `Set-Up LAPS permissions on the target domain` enabled
2. Observe a warning related to the task.
3. The error will appear in the log file `Logs\2024-12-11_045540_HardenAD-Results.log` : `Unable to bind argument to parameter 'ToTranslate' because it is an empty string`.

Here the log about the error :
```
2024/12/11 16:55:35	[DBUG]	--- ----: Calling function Set-LapsPermissions with parameters CUSTOM
2024/12/11 16:55:37	[DBUG]	--- ----: function's ended
2024/12/11 16:55:37	[DBUG]	--- ----: TaskID     = 135
2024/12/11 16:55:37	[DBUG]	--- ----: TaskName   = Setup LAPS permissions over the domain
2024/12/11 16:55:37	[DBUG]	--- ----: TaskResult = warning
2024/12/11 16:55:37	[DBUG]	--- ----: Message    =         Failed to apply Permission on one or more OU. (Unable to bind argument to parameter 'ToTranslate' because it is an empty string)

```
### Quick Fix
To resolve this issue, uncomment the line that assigns a value to `$TargetOU`.  
**Before:**
```powershell
# $TargetOU = $Granted.Target
```
**After:**
```powershell
$TargetOU = $Granted.Target
```
By uncommenting the line, the script will have a valid value for $TargetOU (%DN%) , which will allow the translation process to proceed without errors.