### PR TITLE
Fixed typo in Get-Date format used to generate PolicyDefinitions fold…

### DIFF
--- a/Modules/file.psm1
+++ b/Modules/file.psm1
@@ -89,7 +89,7 @@ Function Set-GpoCentralStore {
     if (Test-Path $GPOCentralStore) 
     {
         # Rename the current repository
-        $UniqueId = (Get-Date -Format yyyy-MM-yy_HHmmss)
+        $UniqueId = (Get-Date -Format yyyy-MM-dd_HHmmss)
         try {
             Rename-Item "$GPOCentralStore\PolicyDefinitions" "$GPOCentralStore\PolicyDefinitions-$UniqueId" -ErrorAction SilentlyContinue
             $dbgMess += (Get-Date -UFormat "%Y-%m-%d %T ") + "---> PolicyDefinitions has been renamed to PolicyDefinitions-$UniqueID"


### PR DESCRIPTION
**Describe the bug**
The function `Set-GpoCentralStore` store a copy of previous PolicyDefinitions in a folder `PolicyDefinitions-$UniqueId`, where `$UniqueId` is a timestamp. However, during the `$UniqueId` generation, the year is used instead of the day. 

This pull request should fix what seems to me to be a typo.