### PR TITLE
Gpo HAD-TS-PDC-Flush-admin-groups configuration inconsistency

### DIFF
--- a/Inputs/GroupPolicies/HAD-TS-PDC-Flush-admin-groups/{A8C72199-7FB0-4234-A737-4E5843814F1E}/DomainSysvol/GPO/Machine/Scripts/Startup/HAD_TS-PDC_Flush-admin-groups/Config/Config.xml
+++ b/Inputs/GroupPolicies/HAD-TS-PDC-Flush-admin-groups/{A8C72199-7FB0-4234-A737-4E5843814F1E}/DomainSysvol/GPO/Machine/Scripts/Startup/HAD_TS-PDC_Flush-admin-groups/Config/Config.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-16"?>
 <Config>
-    <Group Name="L-S-T0_LocalAdmins_Servers"/>
+    <Group Name="t0-LA-srv"/>
 </Config>

--- a/Inputs/GroupPolicies/HAD-TS-PDC-Flush-admin-groups/{A8C72199-7FB0-4234-A737-4E5843814F1E}/DomainSysvol/GPO/Machine/Scripts/Startup/HAD_TS-PDC_Flush-admin-groups/Config/Config.xml.backup
+++ b/Inputs/GroupPolicies/HAD-TS-PDC-Flush-admin-groups/{A8C72199-7FB0-4234-A737-4E5843814F1E}/DomainSysvol/GPO/Machine/Scripts/Startup/HAD_TS-PDC_Flush-admin-groups/Config/Config.xml.backup
@@ -1,9 +1,4 @@
 <?xml version="1.0" encoding="utf-16"?>
 <Config>
     <Group Name="t0-LA-srv"/>
-    <Group Name="t1-LA-srv"/>
-    <Group Name="t1l-LA-srv"/>
-    <Group Name="t0-LA-wks"/>
-    <Group Name="t2-LA-wks"/>
-    <Group Name="t2l-LA-wks"/>
 </Config>


### PR DESCRIPTION
**Describe the bug**
Commit a683f78 didn't fixed the bug #71, as its changes were made in Config.xml but not in Config.xml.backup.

As the function `Convert-GpoPreferencesXml` from groupPolicy.psm1 [use the backup file when it exists](https://github.com/LoicVeirman/HardenAD/blob/22b8064f863f766bf4c251f81996f260c9ab81a0/Modules/groupPolicy.psm1#L191), and as the backup file is present in the git repo, the changes from commit a683f78 had no effect and the following groups are still flushed :
- L-S-T1_LocalAdmins_Servers
- L-S-T1L_LocalAdmins_Servers
- L-S-T0_LocalAdmins_Workstations
- L-S-T2_LocalAdmins_Workstations
- L-S-T2L_LocalAdmins_Workstations

This pull request brings the config.xml.backup file into consistency with the config.xml file, and restores the use of the translation variable rather than the raw group name.